### PR TITLE
storage back done

### DIFF
--- a/back-end/graphql/generated/schema.graphql
+++ b/back-end/graphql/generated/schema.graphql
@@ -167,6 +167,7 @@ input OrderItemInput {
 }
 
 type Query {
+  asset(id: ID, qrCode: String): StorageAsset
   catalogCategories: [CatalogCategory!]!
   catalogItemTypes(categoryId: ID): [CatalogItemType!]!
   catalogProduct(id: ID!): CatalogProduct
@@ -176,6 +177,7 @@ type Query {
   orders: [Order!]!
   receive(id: ID!): Receive
   receives: [Receive!]!
+  storageAssets: [StorageAsset!]!
 }
 
 type Receive {
@@ -203,4 +205,30 @@ type ReceivedAsset {
   id: ID!
   qrCode: String!
   serialNumber: String
+}
+
+type StorageAsset {
+  assetCode: String!
+  assetName: String!
+  assetStatus: String!
+  category: String!
+  conditionStatus: String!
+  createdAt: String!
+  currencyCode: String!
+  department: String!
+  id: ID!
+  itemType: String!
+  orderId: ID!
+  qrCode: String!
+  receiveNote: String
+  receivedAt: String!
+  requestDate: String!
+  requestNumber: String!
+  requester: String!
+  serialNumber: String
+  storageId: ID
+  storageName: String!
+  storageType: String
+  unitCost: Float
+  updatedAt: String!
 }

--- a/back-end/graphql/generated/types.ts
+++ b/back-end/graphql/generated/types.ts
@@ -357,6 +357,7 @@ export type OrderItemInput = {
 
 export type Query = {
   __typename?: 'Query';
+  asset?: Maybe<StorageAsset>;
   catalogCategories: Array<CatalogCategory>;
   catalogItemTypes: Array<CatalogItemType>;
   catalogProduct?: Maybe<CatalogProduct>;
@@ -366,6 +367,13 @@ export type Query = {
   orders: Array<Order>;
   receive?: Maybe<Receive>;
   receives: Array<Receive>;
+  storageAssets: Array<StorageAsset>;
+};
+
+
+export type QueryAssetArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  qrCode?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -428,6 +436,33 @@ export type ReceivedAsset = {
   id: Scalars['ID']['output'];
   qrCode: Scalars['String']['output'];
   serialNumber?: Maybe<Scalars['String']['output']>;
+};
+
+export type StorageAsset = {
+  __typename?: 'StorageAsset';
+  assetCode: Scalars['String']['output'];
+  assetName: Scalars['String']['output'];
+  assetStatus: Scalars['String']['output'];
+  category: Scalars['String']['output'];
+  conditionStatus: Scalars['String']['output'];
+  createdAt: Scalars['String']['output'];
+  currencyCode: Scalars['String']['output'];
+  department: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  itemType: Scalars['String']['output'];
+  orderId: Scalars['ID']['output'];
+  qrCode: Scalars['String']['output'];
+  receiveNote?: Maybe<Scalars['String']['output']>;
+  receivedAt: Scalars['String']['output'];
+  requestDate: Scalars['String']['output'];
+  requestNumber: Scalars['String']['output'];
+  requester: Scalars['String']['output'];
+  serialNumber?: Maybe<Scalars['String']['output']>;
+  storageId?: Maybe<Scalars['ID']['output']>;
+  storageName: Scalars['String']['output'];
+  storageType?: Maybe<Scalars['String']['output']>;
+  unitCost?: Maybe<Scalars['Float']['output']>;
+  updatedAt: Scalars['String']['output'];
 };
 
 
@@ -521,6 +556,7 @@ export type ResolversTypes = {
   Receive: ResolverTypeWrapper<Receive>;
   ReceiveOrderItemPayload: ResolverTypeWrapper<ReceiveOrderItemPayload>;
   ReceivedAsset: ResolverTypeWrapper<ReceivedAsset>;
+  StorageAsset: ResolverTypeWrapper<StorageAsset>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
 };
 
@@ -546,6 +582,7 @@ export type ResolversParentTypes = {
   Receive: Receive;
   ReceiveOrderItemPayload: ReceiveOrderItemPayload;
   ReceivedAsset: ReceivedAsset;
+  StorageAsset: StorageAsset;
   String: Scalars['String']['output'];
 };
 
@@ -700,6 +737,7 @@ export type OrderItemResolvers<ContextType = GraphQLContext, ParentType extends 
 };
 
 export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  asset?: Resolver<Maybe<ResolversTypes['StorageAsset']>, ParentType, ContextType, Partial<QueryAssetArgs>>;
   catalogCategories?: Resolver<Array<ResolversTypes['CatalogCategory']>, ParentType, ContextType>;
   catalogItemTypes?: Resolver<Array<ResolversTypes['CatalogItemType']>, ParentType, ContextType, Partial<QueryCatalogItemTypesArgs>>;
   catalogProduct?: Resolver<Maybe<ResolversTypes['CatalogProduct']>, ParentType, ContextType, RequireFields<QueryCatalogProductArgs, 'id'>>;
@@ -709,6 +747,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   orders?: Resolver<Array<ResolversTypes['Order']>, ParentType, ContextType>;
   receive?: Resolver<Maybe<ResolversTypes['Receive']>, ParentType, ContextType, RequireFields<QueryReceiveArgs, 'id'>>;
   receives?: Resolver<Array<ResolversTypes['Receive']>, ParentType, ContextType>;
+  storageAssets?: Resolver<Array<ResolversTypes['StorageAsset']>, ParentType, ContextType>;
 };
 
 export type ReceiveResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Receive'] = ResolversParentTypes['Receive']> = {
@@ -741,6 +780,33 @@ export type ReceivedAssetResolvers<ContextType = GraphQLContext, ParentType exte
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type StorageAssetResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['StorageAsset'] = ResolversParentTypes['StorageAsset']> = {
+  assetCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  assetName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  assetStatus?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  category?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  conditionStatus?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  currencyCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  department?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  itemType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  orderId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  qrCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  receiveNote?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  receivedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  requestDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  requestNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  requester?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  serialNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  storageId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  storageName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  storageType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  unitCost?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type Resolvers<ContextType = GraphQLContext> = {
   CatalogCategory?: CatalogCategoryResolvers<ContextType>;
   CatalogItemType?: CatalogItemTypeResolvers<ContextType>;
@@ -755,5 +821,6 @@ export type Resolvers<ContextType = GraphQLContext> = {
   Receive?: ReceiveResolvers<ContextType>;
   ReceiveOrderItemPayload?: ReceiveOrderItemPayloadResolvers<ContextType>;
   ReceivedAsset?: ReceivedAssetResolvers<ContextType>;
+  StorageAsset?: StorageAssetResolvers<ContextType>;
 };
 

--- a/back-end/graphql/resolvers/queries/asset/getAssetByIdOrQrCode.ts
+++ b/back-end/graphql/resolvers/queries/asset/getAssetByIdOrQrCode.ts
@@ -1,0 +1,12 @@
+import type { QueryResolvers } from "../../../generated/types.ts";
+import { getStorageAssetDetail } from "../../../../lib/assets.ts";
+
+export const asset: NonNullable<QueryResolvers["asset"]> = (
+  _parent,
+  args,
+  context,
+) =>
+  getStorageAssetDetail(context.db, {
+    id: args.id ?? null,
+    qrCode: args.qrCode ?? null,
+  });

--- a/back-end/graphql/resolvers/queries/asset/getStorageAssets.ts
+++ b/back-end/graphql/resolvers/queries/asset/getStorageAssets.ts
@@ -1,0 +1,8 @@
+import type { QueryResolvers } from "../../../generated/types.ts";
+import { listStorageAssets } from "../../../../lib/assets.ts";
+
+export const storageAssets: NonNullable<QueryResolvers["storageAssets"]> = (
+  _parent,
+  _args,
+  context,
+) => listStorageAssets(context.db);

--- a/back-end/graphql/resolvers/queries/index.ts
+++ b/back-end/graphql/resolvers/queries/index.ts
@@ -1,3 +1,5 @@
+export * from "./asset/getAssetByIdOrQrCode.ts";
+export * from "./asset/getStorageAssets.ts";
 export * from "./catalog/getCatalogCategories.ts";
 export * from "./catalog/getCatalogItemTypes.ts";
 export * from "./catalog/getCatalogProducts.ts";

--- a/back-end/graphql/schema/asset.ts
+++ b/back-end/graphql/schema/asset.ts
@@ -1,0 +1,32 @@
+export const AssetTypeDefs = `
+  type StorageAsset {
+    id: ID!
+    assetCode: String!
+    qrCode: String!
+    assetName: String!
+    category: String!
+    itemType: String!
+    serialNumber: String
+    conditionStatus: String!
+    assetStatus: String!
+    storageId: ID
+    storageName: String!
+    storageType: String
+    receivedAt: String!
+    receiveNote: String
+    orderId: ID!
+    requestNumber: String!
+    requestDate: String!
+    requester: String!
+    department: String!
+    unitCost: Float
+    currencyCode: String!
+    createdAt: String!
+    updatedAt: String!
+  }
+
+  type Query {
+    storageAssets: [StorageAsset!]!
+    asset(id: ID, qrCode: String): StorageAsset
+  }
+`;

--- a/back-end/graphql/schema/index.ts
+++ b/back-end/graphql/schema/index.ts
@@ -1,3 +1,4 @@
+import { AssetTypeDefs } from "./asset.ts";
 import { mergeTypeDefs } from "@graphql-tools/merge";
 import { CatalogTypeDefs } from "./catalog.ts";
 import { NotificationTypeDefs } from "./notification.ts";
@@ -5,6 +6,7 @@ import { OrderTypeDefs } from "./order.ts";
 import { ReceiveTypeDefs } from "./receive.ts";
 
 export const typeDefs = mergeTypeDefs([
+  AssetTypeDefs,
   CatalogTypeDefs,
   NotificationTypeDefs,
   OrderTypeDefs,

--- a/back-end/lib/assets.ts
+++ b/back-end/lib/assets.ts
@@ -1,0 +1,171 @@
+import { asc, eq, isNotNull, or } from "drizzle-orm";
+import {
+  assets,
+  departments,
+  orderItems,
+  orders,
+  receiveItems,
+  receives,
+  storage,
+} from "../database/schema.ts";
+import type { AppDb } from "./db.ts";
+import { parseIntegerId } from "./reference-resolvers.ts";
+
+type StorageAssetRow = {
+  id: number;
+  assetCode: string;
+  qrCode: string;
+  assetName: string;
+  category: string;
+  itemType: string;
+  serialNumber: string | null;
+  conditionStatus: string;
+  assetStatus: string;
+  storageId: number | null;
+  storageName: string | null;
+  storageType: string | null;
+  receivedAt: string;
+  receiveNote: string | null;
+  orderId: number;
+  requestNumber: string | null;
+  requestDate: string | null;
+  requesterName: string | null;
+  departmentName: string | null;
+  unitCost: number | null;
+  currencyCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StorageAssetRecord = {
+  id: string;
+  assetCode: string;
+  qrCode: string;
+  assetName: string;
+  category: string;
+  itemType: string;
+  serialNumber: string | null;
+  conditionStatus: string;
+  assetStatus: string;
+  storageId: string | null;
+  storageName: string;
+  storageType: string | null;
+  receivedAt: string;
+  receiveNote: string | null;
+  orderId: string;
+  requestNumber: string;
+  requestDate: string;
+  requester: string;
+  department: string;
+  unitCost: number | null;
+  currencyCode: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const storageAssetSelection = {
+  id: assets.id,
+  assetCode: assets.assetCode,
+  qrCode: assets.qrCode,
+  assetName: assets.assetName,
+  category: assets.category,
+  itemType: assets.itemType,
+  serialNumber: assets.serialNumber,
+  conditionStatus: assets.conditionStatus,
+  assetStatus: assets.assetStatus,
+  storageId: storage.id,
+  storageName: storage.storageName,
+  storageType: storage.storageType,
+  receivedAt: receives.receivedAt,
+  receiveNote: receiveItems.note,
+  orderId: orders.id,
+  requestNumber: orders.requestNumber,
+  requestDate: orders.requestDate,
+  requesterName: orders.requesterName,
+  departmentName: departments.departmentName,
+  unitCost: orderItems.unitCost,
+  currencyCode: orderItems.currencyCode,
+  createdAt: assets.createdAt,
+  updatedAt: assets.updatedAt,
+};
+
+function mapStorageAsset(row: StorageAssetRow): StorageAssetRecord {
+  const fallbackRequestDate = row.requestDate ?? row.receivedAt.slice(0, 10);
+  const fallbackRequestNumber = `REQ-${fallbackRequestDate.replaceAll("-", "")}-${String(
+    row.orderId,
+  ).padStart(3, "0")}`;
+
+  return {
+    id: String(row.id),
+    assetCode: row.assetCode,
+    qrCode: row.qrCode,
+    assetName: row.assetName,
+    category: row.category,
+    itemType: row.itemType,
+    serialNumber: row.serialNumber,
+    conditionStatus: row.conditionStatus,
+    assetStatus: row.assetStatus,
+    storageId: row.storageId === null ? null : String(row.storageId),
+    storageName: row.storageName ?? "Main warehouse / Intake",
+    storageType: row.storageType,
+    receivedAt: row.receivedAt,
+    receiveNote: row.receiveNote,
+    orderId: String(row.orderId),
+    requestNumber: row.requestNumber ?? fallbackRequestNumber,
+    requestDate: fallbackRequestDate,
+    requester: row.requesterName ?? "",
+    department: row.departmentName ?? "IT Office",
+    unitCost: row.unitCost,
+    currencyCode: row.currencyCode ?? "MNT",
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function buildStorageAssetsBaseQuery(db: AppDb) {
+  return db
+    .select(storageAssetSelection)
+    .from(assets)
+    .innerJoin(receiveItems, eq(assets.receiveItemId, receiveItems.id))
+    .innerJoin(receives, eq(receiveItems.receiveId, receives.id))
+    .innerJoin(orders, eq(receives.orderId, orders.id))
+    .leftJoin(departments, eq(orders.departmentId, departments.id))
+    .leftJoin(storage, eq(assets.currentStorageId, storage.id))
+    .leftJoin(orderItems, eq(receiveItems.orderItemId, orderItems.id));
+}
+
+export async function listStorageAssets(
+  db: AppDb,
+): Promise<StorageAssetRecord[]> {
+  const rows = await buildStorageAssetsBaseQuery(db)
+    .where(isNotNull(assets.currentStorageId))
+    .orderBy(asc(storage.storageName), asc(assets.assetName), asc(assets.id));
+
+  return rows.map(mapStorageAsset);
+}
+
+export async function getStorageAssetDetail(
+  db: AppDb,
+  input: { id?: string | null; qrCode?: string | null },
+): Promise<StorageAssetRecord | null> {
+  const normalizedQrCode = input.qrCode?.trim() || null;
+  const normalizedId = input.id?.trim() || null;
+
+  if (!normalizedId && !normalizedQrCode) {
+    throw new Error("Either asset id or qrCode is required.");
+  }
+
+  const filters = [];
+  if (normalizedId) {
+    filters.push(eq(assets.id, parseIntegerId("Asset id", normalizedId)));
+  }
+  if (normalizedQrCode) {
+    filters.push(eq(assets.qrCode, normalizedQrCode));
+  }
+
+  const [row] = await buildStorageAssetsBaseQuery(db)
+    .where(or(...filters))
+    .limit(1);
+
+  return row ? mapStorageAsset(row) : null;
+}

--- a/front-end/app/(dashboard)/_graphql/storage/storage-api.ts
+++ b/front-end/app/(dashboard)/_graphql/storage/storage-api.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { gql } from "@apollo/client/core";
+import { apolloClient } from "@/app/providers/apolloClient";
+
+export type StorageAssetDto = {
+  id: string;
+  assetCode: string;
+  qrCode: string;
+  assetName: string;
+  category: string;
+  itemType: string;
+  serialNumber: string | null;
+  conditionStatus: string;
+  assetStatus: string;
+  storageId: string | null;
+  storageName: string;
+  storageType: string | null;
+  receivedAt: string;
+  receiveNote: string | null;
+  orderId: string;
+  requestNumber: string;
+  requestDate: string;
+  requester: string;
+  department: string;
+  unitCost: number | null;
+  currencyCode: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const storageAssetFields = gql`
+  fragment StorageAssetFields on StorageAsset {
+    id
+    assetCode
+    qrCode
+    assetName
+    category
+    itemType
+    serialNumber
+    conditionStatus
+    assetStatus
+    storageId
+    storageName
+    storageType
+    receivedAt
+    receiveNote
+    orderId
+    requestNumber
+    requestDate
+    requester
+    department
+    unitCost
+    currencyCode
+    createdAt
+    updatedAt
+  }
+`;
+
+const storageAssetsQuery = gql`
+  ${storageAssetFields}
+
+  query StorageAssets {
+    storageAssets {
+      ...StorageAssetFields
+    }
+  }
+`;
+
+const assetDetailQuery = gql`
+  ${storageAssetFields}
+
+  query AssetDetail($id: ID, $qrCode: String) {
+    asset(id: $id, qrCode: $qrCode) {
+      ...StorageAssetFields
+    }
+  }
+`;
+
+export async function fetchStorageAssetsRequest() {
+  const { data } = await apolloClient.query<{ storageAssets: StorageAssetDto[] }>({
+    query: storageAssetsQuery,
+    fetchPolicy: "no-cache",
+  });
+
+  return data?.storageAssets ?? [];
+}
+
+export async function fetchStorageAssetDetailRequest(input: {
+  id?: string | null;
+  qrCode?: string | null;
+}) {
+  const normalizedId = input.id?.trim() || null;
+  const normalizedQrCode = input.qrCode?.trim() || null;
+
+  const { data } = await apolloClient.query<{ asset: StorageAssetDto | null }>({
+    query: assetDetailQuery,
+    variables: {
+      id: normalizedId,
+      qrCode: normalizedQrCode,
+    },
+    fetchPolicy: "no-cache",
+  });
+
+  return data?.asset ?? null;
+}

--- a/front-end/app/_components/role/InventoryStorageSection.tsx
+++ b/front-end/app/_components/role/InventoryStorageSection.tsx
@@ -1,82 +1,275 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { formatCurrency, formatDisplayDate, useOrdersStore } from "../../_lib/order-store";
+import { useEffect, useMemo, useState } from "react";
+import {
+  fetchStorageAssetDetailRequest,
+  fetchStorageAssetsRequest,
+  type StorageAssetDto,
+} from "@/app/(dashboard)/_graphql/storage/storage-api";
+import { formatCurrency, formatDisplayDate } from "../../_lib/order-store";
 import { EmptyState, WorkspaceShell } from "../shared/WorkspacePrimitives";
-import { buildQrToken, inferCategory } from "../receive/receiveData";
 
 const ACTIONS = ["Dispose", "Census", "Missing", "Audit"] as const;
-const CATEGORIES = ["IT Equipment", "Office Equipment", "Mobile Devices", "Network Equipment", "Furniture", "Other Assets"] as const;
-const GRID = "grid grid-cols-[42px_96px_1.45fr_112px_116px_122px_108px_108px_110px_48px]";
+const CATEGORIES = [
+  "IT Equipment",
+  "Office Equipment",
+  "Mobile Devices",
+  "Network Equipment",
+  "Furniture",
+  "Other Assets",
+] as const;
+const GRID =
+  "grid grid-cols-[42px_96px_1.45fr_112px_116px_122px_108px_108px_110px_48px]";
 
 export function InventoryStorageSection() {
-  const orders = useOrdersStore();
-  const storedOrders = useMemo(() => orders.filter((order) => order.status === "received_inventory" || order.status === "assigned_hr"), [orders]);
-  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
-  const selectedOrder = storedOrders.find((order) => order.id === selectedOrderId) ?? null;
-  const groups = storedOrders.map((order) => {
-    const assetIds = order.assetIds.length > 0 ? order.assetIds : order.serialNumbers.length > 0 ? order.serialNumbers : [order.id];
-    return {
-      order,
-      assetIds,
-      rows: assetIds.map((assetId, index) => ({
-        id: `${order.id}-${assetId}-${index}`,
-        assetId,
-        serialNumber: order.serialNumbers[index] ?? order.serialNumbers[0] ?? assetId,
-        item: order.items[0],
-        category: inferCategory(order.items[0]?.name ?? "Asset"),
-      })),
-    };
-  });
-  const totalRows = groups.reduce((sum, group) => sum + group.rows.length, 0);
+  const [assets, setAssets] = useState<StorageAssetDto[]>([]);
+  const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
+  const [selectedAsset, setSelectedAsset] = useState<StorageAssetDto | null>(null);
+  const [lookupValue, setLookupValue] = useState("");
+  const [searchValue, setSearchValue] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  if (selectedOrder) {
-    const item = selectedOrder.items[0];
-    const assetIds = selectedOrder.assetIds.length > 0 ? selectedOrder.assetIds : selectedOrder.serialNumbers.length > 0 ? selectedOrder.serialNumbers : [selectedOrder.id];
+  useEffect(() => {
+    let isMounted = true;
+
+    void (async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const nextAssets = await fetchStorageAssetsRequest();
+        if (!isMounted) return;
+
+        setAssets(nextAssets);
+      } catch (error) {
+        if (!isMounted) return;
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Failed to load storage assets.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedAssetId) {
+      setSelectedAsset(null);
+      return;
+    }
+
+    let isMounted = true;
+
+    void (async () => {
+      setIsDetailLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const detail = await fetchStorageAssetDetailRequest({ id: selectedAssetId });
+        if (!isMounted) return;
+        setSelectedAsset(detail);
+      } catch (error) {
+        if (!isMounted) return;
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Failed to load asset detail.",
+        );
+      } finally {
+        if (isMounted) {
+          setIsDetailLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedAssetId]);
+
+  const visibleAssets = useMemo(() => {
+    const normalizedQuery = searchValue.trim().toLowerCase();
+    if (!normalizedQuery) return assets;
+
+    return assets.filter((asset) =>
+      [
+        asset.id,
+        asset.assetCode,
+        asset.assetName,
+        asset.requestNumber,
+        asset.requester,
+        asset.department,
+        asset.storageName,
+        asset.serialNumber ?? "",
+        asset.qrCode,
+      ].some((value) => value.toLowerCase().includes(normalizedQuery)),
+    );
+  }, [assets, searchValue]);
+
+  const categoryCounts = useMemo(
+    () =>
+      CATEGORIES.map((category) => ({
+        category,
+        count: visibleAssets.filter((asset) => mapCategory(asset.category) === category)
+          .length,
+      })),
+    [visibleAssets],
+  );
+
+  async function handleLookupSubmit() {
+    const value = lookupValue.trim();
+    if (!value) return;
+
+    setIsDetailLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const detail = await fetchStorageAssetDetailRequest({
+        id: /^\d+$/.test(value) ? value : null,
+        qrCode: /^\d+$/.test(value) ? null : value,
+      });
+
+      if (!detail) {
+        setErrorMessage("No asset matched that asset ID or QR code.");
+        return;
+      }
+
+      setSelectedAsset(detail);
+      setSelectedAssetId(detail.id);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Failed to look up asset detail.",
+      );
+    } finally {
+      setIsDetailLoading(false);
+    }
+  }
+
+  if (selectedAsset) {
     return (
-      <WorkspaceShell title="Storage" subtitle="Audit and control received inventory." backgroundClassName="bg-[linear-gradient(180deg,#e8f3ff_0%,#f7fbff_56%,#ffffff_100%)]">
-        <button type="button" onClick={() => setSelectedOrderId(null)} className="mb-4 text-[14px] font-medium text-[#334155]">{"<-"} Back to Storage Assets</button>
+      <WorkspaceShell
+        title="Storage"
+        subtitle="Audit and control received inventory."
+        backgroundClassName="bg-[linear-gradient(180deg,#e8f3ff_0%,#f7fbff_56%,#ffffff_100%)]"
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setSelectedAsset(null);
+            setSelectedAssetId(null);
+          }}
+          className="mb-4 text-[14px] font-medium text-[#334155]"
+        >
+          {"<-"} Back to Storage Assets
+        </button>
         <div className="grid gap-5 xl:grid-cols-[0.85fr_1.65fr]">
           <section className="overflow-hidden rounded-[18px] border border-[#d9e6f3] bg-white shadow-[0_18px_40px_rgba(148,163,184,0.12)]">
-            <div className="border-b border-[#e6edf5] px-5 py-4 text-[24px] font-semibold text-[#0f172a]">Asset Detail</div>
+            <div className="border-b border-[#e6edf5] px-5 py-4 text-[24px] font-semibold text-[#0f172a]">
+              Asset Detail
+            </div>
             <div className="space-y-4 p-5">
               <div className="rounded-[14px] bg-[#eef5fc] p-4">
                 <div className="grid grid-cols-[72px_1fr] gap-3">
-                  <div className="flex h-[88px] items-center justify-center rounded-[10px] border border-[#d8e6f3] bg-white text-[24px]">QR</div>
-                  <div className="flex h-[88px] items-center justify-center rounded-[10px] border border-[#d8e6f3] bg-[linear-gradient(135deg,#35a7ff_0%,#2563eb_52%,#8cd8ff_100%)] px-4 text-center text-[15px] font-semibold text-white">{item?.name ?? "Stored Item"}</div>
+                  <div className="flex h-[88px] items-center justify-center rounded-[10px] border border-[#d8e6f3] bg-white text-[24px]">
+                    QR
+                  </div>
+                  <div className="flex h-[88px] items-center justify-center rounded-[10px] border border-[#d8e6f3] bg-[linear-gradient(135deg,#35a7ff_0%,#2563eb_52%,#8cd8ff_100%)] px-4 text-center text-[15px] font-semibold text-white">
+                    {selectedAsset.assetName}
+                  </div>
                 </div>
-                <p className="mt-3 text-[11px] leading-5 text-[#475569]">{selectedOrder.receivedNote || "Received inventory item now tracked inside storage with generated local QR references."}</p>
+                <p className="mt-3 text-[11px] leading-5 text-[#475569]">
+                  {selectedAsset.receiveNote ||
+                    "Received inventory item now tracked from backend asset and storage records."}
+                </p>
               </div>
               <div className="divide-y divide-[#e8eef5] rounded-[12px] border border-[#e6edf5] bg-[#fcfdff]">
                 {[
-                  ["Asset ID", assetIds[0] ?? selectedOrder.id],
-                  ["Asset Name", item?.name ?? "-"],
-                  ["Department", selectedOrder.department],
-                  ["Location", selectedOrder.storageLocation || "Main warehouse / Intake"],
-                  ["Condition", selectedOrder.receivedCondition === "issue" ? "Damaged" : "Good"],
-                  ["Unit Cost", formatCurrency(item?.unitPrice ?? 0, item?.currencyCode ?? "USD")],
-                  ["Quantity", String(item?.quantity ?? 0)],
-                  ["Assigned", selectedOrder.status === "assigned_hr" ? "Yes" : "No"],
-                ].map(([label, value]) => <div key={label} className="flex items-center justify-between px-4 py-3 text-[13px]"><span className="text-[#64748b]">{label}</span><span className="font-medium text-[#111827]">{value}</span></div>)}
+                  ["Asset ID", selectedAsset.id],
+                  ["Asset Code", selectedAsset.assetCode],
+                  ["Asset Name", selectedAsset.assetName],
+                  ["Department", selectedAsset.department],
+                  ["Location", selectedAsset.storageName],
+                  ["Condition", formatCondition(selectedAsset.conditionStatus)],
+                  [
+                    "Unit Cost",
+                    formatCurrency(
+                      selectedAsset.unitCost ?? 0,
+                      parseCurrency(selectedAsset.currencyCode),
+                    ),
+                  ],
+                  [
+                    "Assigned",
+                    isAssignedStatus(selectedAsset.assetStatus) ? "Yes" : "No",
+                  ],
+                ].map(([label, value]) => (
+                  <div
+                    key={label}
+                    className="flex items-center justify-between px-4 py-3 text-[13px]"
+                  >
+                    <span className="text-[#64748b]">{label}</span>
+                    <span className="font-medium text-[#111827]">{value}</span>
+                  </div>
+                ))}
               </div>
             </div>
           </section>
           <section className="overflow-hidden rounded-[18px] border border-[#d9e6f3] bg-white shadow-[0_18px_40px_rgba(148,163,184,0.12)]">
-            <div className="border-b border-[#e6edf5] px-5 py-4 text-[24px] font-semibold text-[#0f172a]">Asset QR Batch</div>
+            <div className="border-b border-[#e6edf5] px-5 py-4 text-[24px] font-semibold text-[#0f172a]">
+              Asset QR Detail
+            </div>
             <div className="space-y-5 p-5">
+              <div className="flex flex-wrap gap-2">
+                <input
+                  value={lookupValue}
+                  onChange={(event) => setLookupValue(event.target.value)}
+                  placeholder="Enter asset ID or QR-..."
+                  className="h-10 min-w-[260px] flex-1 rounded-[10px] border border-[#dbe7f3] bg-white px-4 text-[12px] outline-none placeholder:text-[#94a3b8]"
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleLookupSubmit()}
+                  className="h-10 rounded-[10px] border border-[#d9e7f2] bg-white px-4 text-[12px] font-medium text-[#0f172a] shadow-[0_1px_2px_rgba(15,23,42,0.06)]"
+                >
+                  {isDetailLoading ? "Looking up..." : "Find"}
+                </button>
+              </div>
               <div className="grid gap-3 md:grid-cols-3">
-                <Field label="Request ID" value={selectedOrder.requestNumber} />
-                <Field label="Request Date" value={formatDisplayDate(selectedOrder.requestDate)} />
-                <Field label="Stored At" value={selectedOrder.storageLocation || "Warehouse B"} />
+                <Field label="Request ID" value={selectedAsset.requestNumber} />
+                <Field
+                  label="Request Date"
+                  value={formatDisplayDate(selectedAsset.requestDate)}
+                />
+                <Field label="Stored At" value={selectedAsset.storageName} />
               </div>
               <div className="rounded-[14px] border border-[#e4ebf3] bg-white px-4 py-4 text-[13px] text-[#475569]">
-                <div className="flex justify-between"><span>Unit Cost</span><span>{formatCurrency(item?.unitPrice ?? 0, item?.currencyCode ?? "USD")}</span></div>
-                <div className="mt-2 flex justify-between"><span>Asset Count</span><span>{assetIds.length}</span></div>
-                <div className="mt-2 flex justify-between border-t border-[#edf2f7] pt-3 text-[20px] font-semibold text-[#111827]"><span>Order Total</span><span>{formatCurrency(selectedOrder.totalAmount, selectedOrder.currencyCode)}</span></div>
+                <div className="flex justify-between">
+                  <span>Requester</span>
+                  <span>{selectedAsset.requester || "-"}</span>
+                </div>
+                <div className="mt-2 flex justify-between">
+                  <span>Serial Number</span>
+                  <span>{selectedAsset.serialNumber || "-"}</span>
+                </div>
+                <div className="mt-2 flex justify-between border-t border-[#edf2f7] pt-3 text-[20px] font-semibold text-[#111827]">
+                  <span>QR Code</span>
+                  <span className="max-w-[70%] truncate text-right">
+                    {selectedAsset.qrCode}
+                  </span>
+                </div>
               </div>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {assetIds.slice(0, 6).map((assetId, index) => <QrCard key={assetId} title={assetId} value={buildQrToken(selectedOrder.id, assetId, selectedOrder.serialNumbers[index] ?? assetId)} />)}
-              </div>
+              <QrCard title={selectedAsset.assetCode} value={selectedAsset.qrCode} />
             </div>
           </section>
         </div>
@@ -85,55 +278,134 @@ export function InventoryStorageSection() {
   }
 
   return (
-    <WorkspaceShell title="Storage Assets" subtitle="Manage your inventory stock levels" backgroundClassName="bg-[linear-gradient(180deg,#dcebfb_0%,#eff7ff_58%,#ffffff_100%)]">
-      {totalRows === 0 ? <EmptyState title="No stored goods yet" description="Received items will appear here right after the receive step." /> : (
+    <WorkspaceShell
+      title="Storage Assets"
+      subtitle="Manage your inventory stock levels"
+      backgroundClassName="bg-[linear-gradient(180deg,#dcebfb_0%,#eff7ff_58%,#ffffff_100%)]"
+    >
+      {errorMessage ? (
+        <EmptyState title="Storage data unavailable" description={errorMessage} />
+      ) : isLoading ? (
+        <EmptyState
+          title="Loading storage assets"
+          description="Pulling live asset and storage records from the backend."
+        />
+      ) : visibleAssets.length === 0 ? (
+        <EmptyState
+          title="No stored goods yet"
+          description="Received items will appear here right after the receive step."
+        />
+      ) : (
         <div className="overflow-hidden rounded-[20px] border border-[#d7e5f3] bg-white shadow-[0_18px_42px_rgba(148,163,184,0.14)]">
-          <div className="bg-[linear-gradient(180deg,#cfe3fb_0%,#d9ebff_26%,#eef6ff_68%,#ffffff_100%)] px-6 pt-6 pb-5">
+          <div className="bg-[linear-gradient(180deg,#cfe3fb_0%,#d9ebff_26%,#eef6ff_68%,#ffffff_100%)] px-6 pb-5 pt-6">
             <div className="flex flex-wrap gap-2">
-              <input placeholder="Search by distribution number, recipient, or department..." className="h-10 min-w-[260px] flex-1 rounded-[10px] border border-[#dbe7f3] bg-white/90 px-4 text-[12px] outline-none placeholder:text-[#94a3b8]" />
-              {ACTIONS.map((action) => <button key={action} type="button" className="h-10 rounded-[10px] border border-[#d9e7f2] bg-white px-4 text-[12px] font-medium text-[#0f172a] shadow-[0_1px_2px_rgba(15,23,42,0.06)]">+ {action}</button>)}
+              <input
+                value={searchValue}
+                onChange={(event) => setSearchValue(event.target.value)}
+                placeholder="Search by QR, asset, requester, or department..."
+                className="h-10 min-w-[260px] flex-1 rounded-[10px] border border-[#dbe7f3] bg-white/90 px-4 text-[12px] outline-none placeholder:text-[#94a3b8]"
+              />
+              {ACTIONS.map((action) => (
+                <button
+                  key={action}
+                  type="button"
+                  className="h-10 rounded-[10px] border border-[#d9e7f2] bg-white px-4 text-[12px] font-medium text-[#0f172a] shadow-[0_1px_2px_rgba(15,23,42,0.06)]"
+                >
+                  + {action}
+                </button>
+              ))}
             </div>
             <div className="mt-5 grid gap-3 md:grid-cols-3 xl:grid-cols-6">
-              {CATEGORIES.map((category) => <div key={category} className="rounded-[16px] border border-[#dbe8f5] bg-[linear-gradient(180deg,#f4f9ff_0%,#e7f1fb_100%)] px-4 py-4 shadow-[0_6px_18px_rgba(148,163,184,0.12)]"><div className="flex items-start justify-between gap-3"><p className="text-[12px] font-semibold leading-5 text-[#334155]">{category}</p><span className="flex h-6 w-6 items-center justify-center rounded-full bg-[rgba(148,163,184,0.22)] text-[11px] text-[#94a3b8]">□</span></div></div>)}
+              {categoryCounts.map(({ category, count }) => (
+                <div
+                  key={category}
+                  className="rounded-[16px] border border-[#dbe8f5] bg-[linear-gradient(180deg,#f4f9ff_0%,#e7f1fb_100%)] px-4 py-4 shadow-[0_6px_18px_rgba(148,163,184,0.12)]"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="text-[12px] font-semibold leading-5 text-[#334155]">
+                      {category}
+                    </p>
+                    <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-[rgba(37,99,235,0.14)] px-2 text-[11px] text-[#2563eb]">
+                      {count}
+                    </span>
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
           <div className="space-y-4 px-4 pb-3">
-            <div className={`${GRID} items-center rounded-[12px] border border-[#e7edf4] bg-[#dfeeff] px-3 py-3 text-[11px] font-medium text-[#334155]`}>
-              <span>No</span><span>ID</span><span>Asset Name</span><span>Date</span><span>Category</span><span>Location</span><span>Condition</span><span>Status</span><span>Unit Cost</span><span />
+            <div
+              className={`${GRID} items-center rounded-[12px] border border-[#e7edf4] bg-[#dfeeff] px-3 py-3 text-[11px] font-medium text-[#334155]`}
+            >
+              <span>No</span>
+              <span>ID</span>
+              <span>Asset Name</span>
+              <span>Date</span>
+              <span>Category</span>
+              <span>Location</span>
+              <span>Condition</span>
+              <span>Status</span>
+              <span>Unit Cost</span>
+              <span />
             </div>
-            {groups.map((group, groupIndex) => (
-              <div key={group.order.id} className="overflow-hidden rounded-[14px] border border-[#dbe7f3] bg-white shadow-[0_8px_22px_rgba(148,163,184,0.10)]">
-                <div className="flex items-center justify-between border-b border-[#e8eef5] bg-[linear-gradient(180deg,#f8fbff_0%,#edf5ff_100%)] px-4 py-3">
-                  <div>
-                    <p className="text-[13px] font-semibold text-[#0f172a]">{group.order.requestNumber}</p>
-                    <p className="mt-1 text-[11px] text-[#64748b]">{group.order.requester} | {group.rows.length} assets | {group.order.storageLocation || "Main warehouse / Intake"}</p>
-                  </div>
-                  <div className="text-right">
-                    <p className="text-[11px] text-[#94a3b8]">Order Total</p>
-                    <p className="text-[13px] font-semibold text-[#111827]">{formatCurrency(group.order.totalAmount, group.order.currencyCode)}</p>
-                  </div>
-                </div>
-                <div className="divide-y divide-[#edf2f7]">
-                  {group.rows.map((row, rowIndex) => (
-                    <button key={row.id} type="button" onClick={() => setSelectedOrderId(group.order.id)} className={`${GRID} w-full items-center px-3 py-3 text-left text-[11px] text-[#334155] hover:bg-[#f8fbff]`}>
-                      <span>{groupIndex * 100 + rowIndex + 1}</span>
-                      <span>{row.assetId}</span>
-                      <span><span className="block font-medium text-[#111827]">{row.item?.name ?? "Asset"}</span><span className="mt-1 block text-[#94a3b8]">{group.order.requestNumber}</span></span>
-                      <span>{formatDisplayDate(group.order.receivedAt ?? group.order.requestDate)}</span>
-                      <span><span className="inline-flex rounded-full border border-[#dbe3ee] bg-[#f8fafc] px-2 py-[2px] text-[10px]">{row.category}</span></span>
-                      <span>{group.order.storageLocation || "Warehouse A"}</span>
-                      <span><ToneBadge tone={group.order.receivedCondition === "issue" ? "warning" : "success"}>{group.order.receivedCondition === "issue" ? "Damaged" : "Good"}</ToneBadge></span>
-                      <span><ToneBadge tone={group.order.status === "assigned_hr" ? "info" : "neutral"}>{group.order.status === "assigned_hr" ? "Assigned" : "Available"}</ToneBadge></span>
-                      <span>{formatCurrency(row.item?.unitPrice ?? 0, row.item?.currencyCode ?? "USD")}</span>
-                      <span className="text-right text-[16px] text-[#94a3b8]">⋮</span>
-                    </button>
-                  ))}
-                </div>
+            <div className="overflow-hidden rounded-[14px] border border-[#dbe7f3] bg-white shadow-[0_8px_22px_rgba(148,163,184,0.10)]">
+              <div className="divide-y divide-[#edf2f7]">
+                {visibleAssets.map((asset, index) => (
+                  <button
+                    key={asset.id}
+                    type="button"
+                    onClick={() => setSelectedAssetId(asset.id)}
+                    className={`${GRID} w-full items-center px-3 py-3 text-left text-[11px] text-[#334155] hover:bg-[#f8fbff]`}
+                  >
+                    <span>{index + 1}</span>
+                    <span>{asset.id}</span>
+                    <span>
+                      <span className="block font-medium text-[#111827]">
+                        {asset.assetName}
+                      </span>
+                      <span className="mt-1 block text-[#94a3b8]">
+                        {asset.requestNumber}
+                      </span>
+                    </span>
+                    <span>{formatDisplayDate(asset.receivedAt)}</span>
+                    <span>
+                      <span className="inline-flex rounded-full border border-[#dbe3ee] bg-[#f8fafc] px-2 py-[2px] text-[10px]">
+                        {mapCategory(asset.category)}
+                      </span>
+                    </span>
+                    <span>{asset.storageName}</span>
+                    <span>
+                      <ToneBadge
+                        tone={asset.conditionStatus === "damaged" ? "warning" : "success"}
+                      >
+                        {formatCondition(asset.conditionStatus)}
+                      </ToneBadge>
+                    </span>
+                    <span>
+                      <ToneBadge
+                        tone={isAssignedStatus(asset.assetStatus) ? "info" : "neutral"}
+                      >
+                        {formatAssetStatus(asset.assetStatus)}
+                      </ToneBadge>
+                    </span>
+                    <span>
+                      {formatCurrency(
+                        asset.unitCost ?? 0,
+                        parseCurrency(asset.currencyCode),
+                      )}
+                    </span>
+                    <span className="text-right text-[16px] text-[#94a3b8]">...</span>
+                  </button>
+                ))}
               </div>
-            ))}
+            </div>
             <div className="flex items-center justify-between px-1 pt-3 text-[10px] text-[#64748b]">
-              <span>0 of {totalRows} row(s) selected.</span>
-              <div className="flex items-center gap-4"><span>Rows per page 10</span><span>Page 1 of 1</span><span>{"< < > >"}</span></div>
+              <span>0 of {visibleAssets.length} row(s) selected.</span>
+              <div className="flex items-center gap-4">
+                <span>Rows per page 10</span>
+                <span>Page 1 of 1</span>
+                <span>{"< < > >"}</span>
+              </div>
             </div>
           </div>
         </div>
@@ -142,16 +414,100 @@ export function InventoryStorageSection() {
   );
 }
 
-function Field({ label, value }: { label: string; value: string }) {
-  return <div className="rounded-[10px] border border-[#d9e5f2] bg-white px-3 py-3"><p className="text-[11px] text-[#94a3b8]">{label}</p><p className="mt-1 text-[13px] text-[#111827]">{value}</p></div>;
+function mapCategory(value: string) {
+  const normalized = value.trim().toLowerCase();
+
+  if (normalized.includes("it")) return "IT Equipment";
+  if (normalized.includes("office")) return "Office Equipment";
+  if (normalized.includes("mobile")) return "Mobile Devices";
+  if (normalized.includes("network")) return "Network Equipment";
+  if (normalized.includes("furniture")) return "Furniture";
+
+  return "Other Assets";
 }
 
-function ToneBadge({ children, tone }: { children: string; tone: "success" | "warning" | "info" | "neutral" }) {
-  const styles = tone === "success" ? "border-[#bbf7d0] bg-[#effdf3] text-[#15803d]" : tone === "warning" ? "border-[#fde68a] bg-[#fff7e8] text-[#d97706]" : tone === "info" ? "border-[#bfdbfe] bg-[#eef4ff] text-[#2563eb]" : "border-[#dbe4ee] bg-[#f8fafc] text-[#64748b]";
-  return <span className={`inline-flex rounded-full border px-2 py-[2px] text-[10px] ${styles}`}>{children}</span>;
+function parseCurrency(value: string) {
+  if (value === "USD" || value === "EUR" || value === "MNT") {
+    return value;
+  }
+
+  return "MNT";
+}
+
+function formatCondition(value: string) {
+  if (value === "damaged") return "Damaged";
+  if (value === "defective") return "Defective";
+  if (value === "fair") return "Fair";
+  if (value === "incomplete") return "Incomplete";
+  if (value === "used") return "Used";
+
+  return "Good";
+}
+
+function isAssignedStatus(value: string) {
+  return value === "assigned" || value === "pendingAssignment";
+}
+
+function formatAssetStatus(value: string) {
+  if (value === "pendingAssignment") return "Pending Assignment";
+  if (value === "assigned") return "Assigned";
+  if (value === "available") return "Available";
+  if (value === "received") return "Received";
+  if (value === "inStorage") return "Available";
+
+  return value;
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[10px] border border-[#d9e5f2] bg-white px-3 py-3">
+      <p className="text-[11px] text-[#94a3b8]">{label}</p>
+      <p className="mt-1 text-[13px] text-[#111827]">{value}</p>
+    </div>
+  );
+}
+
+function ToneBadge({
+  children,
+  tone,
+}: {
+  children: string;
+  tone: "success" | "warning" | "info" | "neutral";
+}) {
+  const styles =
+    tone === "success"
+      ? "border-[#bbf7d0] bg-[#effdf3] text-[#15803d]"
+      : tone === "warning"
+        ? "border-[#fde68a] bg-[#fff7e8] text-[#d97706]"
+        : tone === "info"
+          ? "border-[#bfdbfe] bg-[#eef4ff] text-[#2563eb]"
+          : "border-[#dbe4ee] bg-[#f8fafc] text-[#64748b]";
+
+  return (
+    <span className={`inline-flex rounded-full border px-2 py-[2px] text-[10px] ${styles}`}>
+      {children}
+    </span>
+  );
 }
 
 function QrCard({ title, value }: { title: string; value: string }) {
-  const cells = Array.from({ length: 81 }, (_, index) => ((value.charCodeAt(index % value.length) || 0) + index) % 2 === 0);
-  return <div className="rounded-[12px] border border-[#dbe3ee] bg-white p-3"><div className="grid grid-cols-9 gap-px rounded-[8px] bg-[#f8fbff] p-2">{cells.map((filled, index) => <span key={`${value}-${index}`} className={`h-3 w-3 rounded-[1px] ${filled ? "bg-[#0f172a]" : "bg-[#dbeafe]"}`} />)}</div><p className="mt-2 truncate text-[11px] font-medium text-[#111827]">{title}</p><p className="mt-1 truncate text-[10px] text-[#64748b]">{value}</p></div>;
+  const cells = Array.from(
+    { length: 81 },
+    (_, index) => ((value.charCodeAt(index % value.length) || 0) + index) % 2 === 0,
+  );
+
+  return (
+    <div className="rounded-[12px] border border-[#dbe3ee] bg-white p-3">
+      <div className="grid grid-cols-9 gap-px rounded-[8px] bg-[#f8fbff] p-2">
+        {cells.map((filled, index) => (
+          <span
+            key={`${value}-${index}`}
+            className={`h-3 w-3 rounded-[1px] ${filled ? "bg-[#0f172a]" : "bg-[#dbeafe]"}`}
+          />
+        ))}
+      </div>
+      <p className="mt-2 truncate text-[11px] font-medium text-[#111827]">{title}</p>
+      <p className="mt-1 truncate text-[10px] text-[#64748b]">{value}</p>
+    </div>
+  );
 }

--- a/front-end/graphql/schema.graphql
+++ b/front-end/graphql/schema.graphql
@@ -78,6 +78,7 @@ type Mutation {
   deleteReceive(id: ID!): Boolean!
   markAllNotificationsAsRead(userId: ID): Boolean!
   markNotificationAsRead(id: ID!, userId: ID): Notification
+  receiveOrderItem(catalogId: ID, itemCode: String!, officeId: ID, orderId: ID!, quantityReceived: Int!, receivedAt: String, receivedByUserId: ID, receivedCondition: String!, receivedNote: String, serialNumbers: [String!], storageLocation: String): ReceiveOrderItemPayload!
   updateCatalogProduct(attributes: [CatalogAttributeInput!], categoryId: ID, defaultCurrencyCode: String, defaultUnitCost: Float, description: String, displayName: String, id: ID!, images: [CatalogImageInput!], itemTypeId: ID, itemTypeName: String, productCode: String, status: String, unit: String): CatalogProduct
   updateOrder(approvalMessage: String, approvalTarget: String, assignedAt: String, assignedRole: String, assignedTo: String, currencyCode: String, deliveryDate: String, department: String, departmentId: ID, financeNote: String, financeReviewedAt: String, financeReviewer: String, higherUpNote: String, higherUpReviewedAt: String, higherUpReviewer: String, id: ID!, items: [OrderItemInput!], officeId: ID, orderName: String, receivedAt: String, receivedCondition: String, receivedNote: String, requestDate: String, requestNumber: String, requestedApproverId: String, requestedApproverName: String, requestedApproverRole: String, requester: String, serialNumbers: [String!], status: String, storageLocation: String, totalAmount: Float, userId: ID, whyOrdered: String): Order
   updateReceive(id: ID!, note: String, officeId: ID, orderId: ID, receivedAt: String, receivedByUserId: ID, status: String): Receive
@@ -166,6 +167,7 @@ input OrderItemInput {
 }
 
 type Query {
+  asset(id: ID, qrCode: String): StorageAsset
   catalogCategories: [CatalogCategory!]!
   catalogItemTypes(categoryId: ID): [CatalogItemType!]!
   catalogProduct(id: ID!): CatalogProduct
@@ -175,6 +177,7 @@ type Query {
   orders: [Order!]!
   receive(id: ID!): Receive
   receives: [Receive!]!
+  storageAssets: [StorageAsset!]!
 }
 
 type Receive {
@@ -185,4 +188,47 @@ type Receive {
   receivedAt: String!
   receivedByUserId: ID!
   status: String!
+}
+
+type ReceiveOrderItemPayload {
+  assets: [ReceivedAsset!]!
+  order: Order!
+  receive: Receive!
+}
+
+type ReceivedAsset {
+  assetCode: String!
+  assetName: String!
+  assetStatus: String!
+  conditionStatus: String!
+  currentStorageId: ID
+  id: ID!
+  qrCode: String!
+  serialNumber: String
+}
+
+type StorageAsset {
+  assetCode: String!
+  assetName: String!
+  assetStatus: String!
+  category: String!
+  conditionStatus: String!
+  createdAt: String!
+  currencyCode: String!
+  department: String!
+  id: ID!
+  itemType: String!
+  orderId: ID!
+  qrCode: String!
+  receiveNote: String
+  receivedAt: String!
+  requestDate: String!
+  requestNumber: String!
+  requester: String!
+  serialNumber: String
+  storageId: ID
+  storageName: String!
+  storageType: String
+  unitCost: Float
+  updatedAt: String!
 }


### PR DESCRIPTION
I added real asset/storage GraphQL queries on the backend and exposed:

storageAssets for the storage page list
asset(id:, qrCode:) for QR/detail lookup
Those are wired through asset.ts, assets.ts, and the new query resolvers under back-end/graphql/resolvers/queries/asset. I also regenerated schema/types.

On the frontend, the storage page now fetches real backend asset records instead of synthesizing rows from order-store, and the detail pane can look up an asset by either numeric asset ID or QR text. That work is in storage-api.ts and InventoryStorageSection.tsx. I also refreshed schema.graphql so frontend codegen stays in sync.